### PR TITLE
语言文件解析 getLangJson 方法对象获取改成使用 AST 解析

### DIFF
--- a/kiwi-linter/src/astUtils.ts
+++ b/kiwi-linter/src/astUtils.ts
@@ -20,3 +20,41 @@ export function removeFileComment(code: string, fileName: string) {
   );
   return printer.printFile(sourceFile);
 }
+
+export type Traverse = (node: ts.Node, cb: (n: ts.Node) => boolean | void) => boolean;
+
+/**
+ * TS AST forEach dfs
+ * @param node 待遍历节点
+ * @param cb 回调函数，返回 true 那么会提前停止 dfs，不返回或者返回 false 那么会继续 dfs
+ */
+export const traverse: Traverse = (node, cb) => {
+  const isCbStop = cb(node);
+  if (isCbStop) {
+    return true;
+  }
+  return ts.forEachChild<boolean>(node, node => {
+    const isStop = traverse(node, cb);
+    if (isStop) {
+      return true;
+    }
+    return false;
+  });
+};
+
+/**
+ * 解析 ts 文件字符串，获取对象字符串
+ * @param tsStr js 字符串
+ * @return 对象字符串
+ */
+export const getObjectLiteralExpression = (tsStr: string) => {
+  const sourceFile = ts.createSourceFile('', tsStr, ts.ScriptTarget.ESNext, true);
+  let result: string = '';
+  traverse(sourceFile, node => {
+    if (ts.isObjectLiteralExpression(node)) {
+      result = node.getText();
+      return true;
+    }
+  });
+  return result;
+};

--- a/kiwi-linter/src/test/astUtils.test.ts
+++ b/kiwi-linter/src/test/astUtils.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import * as ts from 'typescript';
+import { traverse, getObjectLiteralExpression } from '../astUtils';
+
+const objectText = `{
+  a: 1,
+  b: 2,
+}`;
+const fileMock = `const obj = ${objectText}`;
+
+const complexObjectText = `{
+  c: {
+    d: [
+      {
+        e: 'any string'
+      },
+      {
+        f: 'some string'
+      },
+    ],
+  },
+  g: () => ({ h: false }),
+}`;
+const complexFileMock = `const complexObj = ${complexObjectText};
+  ${fileMock};
+  export default complexObj
+`;
+
+suite('utils/tsAstHelper', () => {
+  suite('traverse', () => {
+    test('traverse stop', () => {
+      const source = ts.createSourceFile('', fileMock, ts.ScriptTarget.ESNext, true);
+      let traverseTimes = 0;
+
+      traverse(source, node => {
+        traverseTimes++;
+        if (ts.isVariableDeclaration(node)) {
+          return true;
+        }
+      });
+
+      assert.strictEqual(traverseTimes, 4);
+    });
+  });
+
+  suite('getObjectLiteralExpression', () => {
+    test('expect get obj', () => {
+      const text = getObjectLiteralExpression(fileMock);
+
+      assert.strictEqual(text, objectText);
+    });
+
+    test('expect get first complex obj', () => {
+      const complexText = getObjectLiteralExpression(complexFileMock);
+      assert.strictEqual(complexText, complexObjectText);
+    });
+  });
+});

--- a/kiwi-linter/src/utils.ts
+++ b/kiwi-linter/src/utils.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as slash from 'slash2';
 import { pinyin } from 'pinyin-pro';
 import { TranslateAPiEnum } from './define';
+import { getObjectLiteralExpression } from './astUtils';
 
 /**
  * 将对象拍平
@@ -84,13 +85,12 @@ export const getAllFiles = dir =>
  */
 export function getLangJson(fileName) {
   const fileContent = fs.readFileSync(fileName, { encoding: 'utf8' });
-  let obj = fileContent.match(/export\s*default\s*({[\s\S]+);?$/)[1];
-  obj = obj.replace(/\s*;\s*$/, '');
+  let objStr = getObjectLiteralExpression(fileContent);
   let jsObj = {};
   try {
-    jsObj = eval('(' + obj + ')');
+    jsObj = eval('(' + objStr + ')');
   } catch (err) {
-    console.log(obj);
+    console.log(objStr);
     console.error(err);
   }
   return jsObj;


### PR DESCRIPTION
原来使用正则匹配的方式只能解析 `export default {};` 类似这样的代码结构。
有一些特殊需求，比如改成 `export default {} as const;` 这种加了 const 断言的文件就解析不出来了。

所以将获取语言文件对象的方式改成 AST 解析来适应各种场景。 

