### PR TITLE
feat: ignoreDir 和 ignoreFile 配置支持数组形式，并修复在 windows 系统底下 delimiter 适配的问题

### DIFF
--- a/kiwi-cli/README.md
+++ b/kiwi-cli/README.md
@@ -49,7 +49,7 @@ Kiwi 的 CLI 工具
 
   // 可跳过的文件夹名或者文加名，比如docs、mock等，只需要匹配部分路径即可
   // 如实际文件目录是 /src/components/layouts
-  // 可以配置 ignoreDir: ['/src/components/layouts'] 或者 ['/components/layouts']
+  // 可以配置 ignoreDir: '/src/components/layouts' 或者 ['/src/components/layouts']
   // 路径以 / 连接，ignoreFile 也是相同匹配规则
   "ignoreDir": [],
   "ignoreFile": []

--- a/kiwi-cli/README.md
+++ b/kiwi-cli/README.md
@@ -47,9 +47,12 @@ Kiwi 的 CLI 工具
   // import 语句，不同项目请自己配置
   "importI18N": "",
 
-  // 可跳过的文件夹名或者文加名，比如docs、mock等
-  "ignoreDir": "",
-  "ignoreFile": ""
+  // 可跳过的文件夹名或者文加名，比如docs、mock等，只需要匹配部分路径即可
+  // 如实际文件目录是 /src/components/layouts
+  // 可以配置 ignoreDir: ['/src/components/layouts'] 或者 ['/components/layouts']
+  // 路径以 / 连接，ignoreFile 也是相同匹配规则
+  "ignoreDir": [],
+  "ignoreFile": []
 }
 ```
 

--- a/kiwi-cli/src/const.ts
+++ b/kiwi-cli/src/const.ts
@@ -26,8 +26,8 @@ export const PROJECT_CONFIG = {
     },
     defaultTranslateKeyApi: 'Pinyin', // 批量提取文案时生成key值时的默认翻译源
     importI18N: `import I18N from 'src/utils/I18N';`,
-    ignoreDir: '',
-    ignoreFile: ''
+    ignoreDir: [],
+    ignoreFile: []
   },
   langMap: {
     ['en-US']: 'en',

--- a/kiwi-cli/src/extract/file.ts
+++ b/kiwi-cli/src/extract/file.ts
@@ -13,9 +13,10 @@ import * as fs from 'fs';
  * @param  {string} dir 路径
  * @param {ignoreDirectory} 忽略文件夹 {ignoreFile} 忽略的文件
  */
-function getSpecifiedFiles(dir, ignoreDirectory = '', ignoreFile = '') {
+function getSpecifiedFiles(dir, ignoreDirectory = [], ignoreFile = []) {
   return fs.readdirSync(dir).reduce((files, file) => {
     const name = path.join(dir, file);
+
     const isDirectory = fs.statSync(name).isDirectory();
     const isFile = fs.statSync(name).isFile();
 
@@ -23,16 +24,26 @@ function getSpecifiedFiles(dir, ignoreDirectory = '', ignoreFile = '') {
       return files.concat(getSpecifiedFiles(name, ignoreDirectory, ignoreFile));
     }
 
-    const isIgnoreDirectory =
-      !ignoreDirectory ||
-      (ignoreDirectory &&
-        !path
+    const isIncludeDirectory =
+      !(ignoreDirectory || []).length ||
+      !(ignoreDirectory || []).some(ignoreDir => {
+        return path
           .dirname(name)
-          .split('/')
-          .includes(ignoreDirectory));
-    const isIgnoreFile = !ignoreFile || (ignoreFile && path.basename(name) !== ignoreFile);
+          .split(path.sep)
+          .join('/')
+          .includes(ignoreDir);
+      });
 
-    if (isFile && isIgnoreDirectory && isIgnoreFile) {
+    const isIncludeFile =
+      !(ignoreFile || []).length ||
+      !(ignoreFile || []).some(filename =>
+        name
+          .split(path.sep)
+          .join('/')
+          .includes(filename)
+      );
+
+    if (isFile && isIncludeDirectory && isIncludeFile) {
       return files.concat(name);
     }
     return files;

--- a/kiwi-cli/src/extract/file.ts
+++ b/kiwi-cli/src/extract/file.ts
@@ -14,6 +14,9 @@ import * as fs from 'fs';
  * @param {ignoreDirectory} 忽略文件夹 {ignoreFile} 忽略的文件
  */
 function getSpecifiedFiles(dir, ignoreDirectory = [], ignoreFile = []) {
+  const standardIgnoreDirectory = Array.isArray(ignoreDirectory) ? ignoreDirectory : [ignoreDirectory];
+  const standardIgnoreFile = Array.isArray(ignoreFile) ? ignoreFile : [ignoreFile];
+
   return fs.readdirSync(dir).reduce((files, file) => {
     const name = path.join(dir, file);
 
@@ -21,12 +24,12 @@ function getSpecifiedFiles(dir, ignoreDirectory = [], ignoreFile = []) {
     const isFile = fs.statSync(name).isFile();
 
     if (isDirectory) {
-      return files.concat(getSpecifiedFiles(name, ignoreDirectory, ignoreFile));
+      return files.concat(getSpecifiedFiles(name, standardIgnoreDirectory, standardIgnoreFile));
     }
 
     const isIncludeDirectory =
-      !(ignoreDirectory || []).length ||
-      !(ignoreDirectory || []).some(ignoreDir => {
+      !(standardIgnoreDirectory || []).length ||
+      !(standardIgnoreDirectory || []).some(ignoreDir => {
         return path
           .dirname(name)
           .split(path.sep)
@@ -35,8 +38,8 @@ function getSpecifiedFiles(dir, ignoreDirectory = [], ignoreFile = []) {
       });
 
     const isIncludeFile =
-      !(ignoreFile || []).length ||
-      !(ignoreFile || []).some(filename =>
+      !(standardIgnoreFile || []).length ||
+      !(standardIgnoreFile || []).some(filename =>
         name
           .split(path.sep)
           .join('/')


### PR DESCRIPTION
- ignoreDir 和 ignoreFile 配置支持数组形式
- 修复在 windows 系统底下 delimiter 适配的问题